### PR TITLE
add more video services

### DIFF
--- a/client/video.coffee
+++ b/client/video.coffee
@@ -2,7 +2,7 @@
 parse = (text='') ->
   result = {}
   for line in text.split /\r\n?|\n/
-    if args = line.match /^\s*([A-Z]+)\s+([\w\-]+)\s*$/
+    if args = line.match /^\s*([A-Z]+)\s+([\w\.\-]+)\s*$/
       result.player = args[1]
       result.key = args[2]
     else
@@ -28,6 +28,32 @@ embed = ({player, key}) ->
           width="420" height="263"
           frameborder="0"
           allowfullscreen>
+        </iframe>
+      """
+    when 'ARCHIVE'
+      """
+        <iframe
+          src="https://archive.org/embed/#{key}"
+          width="420" height="300"
+          frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true"
+          allowfullscreen>
+        </iframe>
+      """
+    when 'TED'
+      """
+        <iframe
+          src="https://embed-ssl.ted.com/talks/#{key}.html"
+          width="420" height="300"
+          frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen
+          allowFullScreen>
+        </iframe>
+      """
+    when 'TEDX'
+      """
+        <iframe
+          src="http://tedxtalks.ted.com/video/#{key}/player?layout=&amp;read_more=1"
+          width="420" height="300"
+          frameborder="0" scrolling="no">
         </iframe>
       """
     else

--- a/pages/about-video-plugin
+++ b/pages/about-video-plugin
@@ -4,7 +4,7 @@
     {
       "type": "paragraph",
       "id": "d618f0df06ca75db",
-      "text": "The Video Plugin embeds a video player on a wiki page. The video itself must be uploaded to YouTube or Vimeo and the key from that service used to configure the plugin. Drag and drop makes this easy in some cases."
+      "text": "The Video Plugin embeds a video player on a wiki page. The video itself must be uploaded to a supported video site and the key from that service used to configure the plugin. Drag and drop makes this easy in some cases."
     },
     {
       "type": "paragraph",
@@ -24,7 +24,7 @@
     {
       "type": "paragraph",
       "id": "b262d0358a094b85",
-      "text": "You can drag and drop a youtube or vimeo video to a factory and have it turn into an embedded video. Drag the location item (not the tab) for either player. Or drag youtube/vimeo video thumbnails from the google search result pages."
+      "text": "You can drag and drop a video to a factory and have it turn into an embedded video. Drag the location item (not the tab) for either player. Or drag the video thumbnails from the google search result pages."
     },
     {
       "type": "paragraph",
@@ -39,47 +39,7 @@
     {
       "type": "paragraph",
       "id": "0fe016e2e2cec946",
-      "text": "The plugin's text contains the caption and commands specifying player details especially the identification key used to select the video to be played. This can be edited manually."
-    },
-    {
-      "type": "paragraph",
-      "id": "0bd440c25f153ed9",
-      "text": "Find the key for your video in its url or embed code."
-    },
-    {
-      "type": "paragraph",
-      "id": "0965aefa76be52c8",
-      "text": "YouTube keys are letters and digits, like ziMLDgsefi0"
-    },
-    {
-      "type": "code",
-      "id": "fba1060fa13d3f4d",
-      "text": "http://youtu.be/ziMLDgsefi0"
-    },
-    {
-      "type": "code",
-      "id": "65c9b3bdb77605cc",
-      "text": "http://www.youtube.com/watch?v=ziMLDgsefi0"
-    },
-    {
-      "type": "code",
-      "id": "a252d2b4f7c83524",
-      "text": "<iframe width=\"420\" height=\"315\" src=\"//www.youtube.com/embed/ziMLDgsefi0?rel=0\" frameborder=\"0\" allowfullscreen></iframe>"
-    },
-    {
-      "type": "paragraph",
-      "id": "8595e1e06ca0aacc",
-      "text": "Vimeo keys are numbers, like 30340726"
-    },
-    {
-      "type": "code",
-      "id": "290c76f66e3e9c3b",
-      "text": "http://vimeo.com/30340726"
-    },
-    {
-      "type": "code",
-      "id": "dd0ce1f995eb7100",
-      "text": "<iframe src=\"//player.vimeo.com/video/30340726?title=0&amp;byline=0&amp;portrait=0\" width=\"420\" height=\"263\" frameborder=\"0\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+      "text": "The plugin's text contains the caption and commands specifying player details especially the identification key used to select the video to be played. This can be edited manually. Find the key for your video in its url or embed code."
     },
     {
       "type": "paragraph",
@@ -94,12 +54,27 @@
     {
       "type": "paragraph",
       "id": "31ed01021009e01c",
-      "text": "Say <b>YOUTUBE</b> and a key from YouTube."
+      "text": "Say <b>YOUTUBE</b> and a [[Key from YouTube]]."
     },
     {
       "type": "paragraph",
       "id": "2b9d57899e235839",
-      "text": "Say <b>VIMEO</b> and a key from Vimeo."
+      "text": "Say <b>VIMEO</b> and a [[Key from Vimeo]]."
+    },
+    {
+      "type": "paragraph",
+      "id": "b482e0a6e80d235c",
+      "text": "Say <b>ARCHIVE</b> and a [[Key from Internet Archive]]."
+    },
+    {
+      "type": "paragraph",
+      "id": "079161c9324efd8f",
+      "text": "Say <b>TED</b> and a [[Key from a TED Talk]]."
+    },
+    {
+      "type": "paragraph",
+      "id": "6c1ced54ed7e15b9",
+      "text": "Say <b>TEDX</b> and a [[Key from a TEDx Talk]]."
     },
     {
       "type": "paragraph",
@@ -827,6 +802,189 @@
         "text": "Double-click the caption to enter a key or change the caption."
       },
       "date": 1404579288180
+    },
+    {
+      "type": "edit",
+      "id": "d618f0df06ca75db",
+      "item": {
+        "type": "paragraph",
+        "id": "d618f0df06ca75db",
+        "text": "The Video Plugin embeds a video player on a wiki page. The video itself must be uploaded to YouTube, Vimeo or the Internet Archive and the key from that service used to configure the plugin. Drag and drop makes this easy in some cases."
+      },
+      "date": 1416109935792
+    },
+    {
+      "type": "edit",
+      "id": "b262d0358a094b85",
+      "item": {
+        "type": "paragraph",
+        "id": "b262d0358a094b85",
+        "text": "You can drag and drop a video to a factory and have it turn into an embedded video. Drag the location item (not the tab) for either player. Or drag the video thumbnails from the google search result pages."
+      },
+      "date": 1416110002672
+    },
+    {
+      "type": "edit",
+      "id": "31ed01021009e01c",
+      "item": {
+        "type": "paragraph",
+        "id": "31ed01021009e01c",
+        "text": "Say <b>YOUTUBE</b> and a [[Key from YouTube]]."
+      },
+      "date": 1416110194787
+    },
+    {
+      "type": "edit",
+      "id": "2b9d57899e235839",
+      "item": {
+        "type": "paragraph",
+        "id": "2b9d57899e235839",
+        "text": "Say <b>VIMEO</b> and a [[Key from Vimeo]]."
+      },
+      "date": 1416110209380
+    },
+    {
+      "item": {
+        "type": "paragraph",
+        "id": "b482e0a6e80d235c",
+        "text": ""
+      },
+      "id": "b482e0a6e80d235c",
+      "type": "add",
+      "after": "2b9d57899e235839",
+      "date": 1416110214729
+    },
+    {
+      "type": "edit",
+      "id": "b482e0a6e80d235c",
+      "item": {
+        "type": "paragraph",
+        "id": "b482e0a6e80d235c",
+        "text": "Say <b>ARCHIVE</b> and a [[Key from Internet Archive]]."
+      },
+      "date": 1416110240696
+    },
+    {
+      "type": "remove",
+      "id": "0965aefa76be52c8",
+      "date": 1416110638868
+    },
+    {
+      "type": "remove",
+      "id": "fba1060fa13d3f4d",
+      "date": 1416110643438
+    },
+    {
+      "type": "remove",
+      "id": "65c9b3bdb77605cc",
+      "date": 1416110648323
+    },
+    {
+      "type": "remove",
+      "id": "a252d2b4f7c83524",
+      "date": 1416110653353
+    },
+    {
+      "type": "remove",
+      "id": "8595e1e06ca0aacc",
+      "date": 1416110717808
+    },
+    {
+      "type": "remove",
+      "id": "290c76f66e3e9c3b",
+      "date": 1416110721531
+    },
+    {
+      "type": "remove",
+      "id": "dd0ce1f995eb7100",
+      "date": 1416110724999
+    },
+    {
+      "type": "remove",
+      "id": "0bd440c25f153ed9",
+      "date": 1416110754571
+    },
+    {
+      "type": "edit",
+      "id": "0fe016e2e2cec946",
+      "item": {
+        "type": "paragraph",
+        "id": "0fe016e2e2cec946",
+        "text": "The plugin's text contains the caption and commands specifying player details especially the identification key used to select the video to be played. This can be edited manually. Find the key for your video in its url or embed code."
+      },
+      "date": 1416110756852
+    },
+    {
+      "item": {
+        "type": "paragraph",
+        "id": "079161c9324efd8f",
+        "text": ""
+      },
+      "id": "079161c9324efd8f",
+      "type": "add",
+      "after": "b482e0a6e80d235c",
+      "date": 1416113831801
+    },
+    {
+      "type": "edit",
+      "id": "079161c9324efd8f",
+      "item": {
+        "type": "paragraph",
+        "id": "079161c9324efd8f",
+        "text": "Say TED and a Key from Ted"
+      },
+      "date": 1416113857396
+    },
+    {
+      "type": "edit",
+      "id": "079161c9324efd8f",
+      "item": {
+        "type": "paragraph",
+        "id": "079161c9324efd8f",
+        "text": "Say TED and a [[Key from a TED Talk]]."
+      },
+      "date": 1416113899787
+    },
+    {
+      "type": "edit",
+      "id": "079161c9324efd8f",
+      "item": {
+        "type": "paragraph",
+        "id": "079161c9324efd8f",
+        "text": "Say <b>TED</b> and a [[Key from a TED Talk]]."
+      },
+      "date": 1416113913015
+    },
+    {
+      "item": {
+        "type": "paragraph",
+        "id": "6c1ced54ed7e15b9",
+        "text": ""
+      },
+      "id": "6c1ced54ed7e15b9",
+      "type": "add",
+      "after": "079161c9324efd8f",
+      "date": 1416114081262
+    },
+    {
+      "type": "edit",
+      "id": "6c1ced54ed7e15b9",
+      "item": {
+        "type": "paragraph",
+        "id": "6c1ced54ed7e15b9",
+        "text": "Say <b>TEDX</b> and a [[Key from a TEDx Talk]]."
+      },
+      "date": 1416114109486
+    },
+    {
+      "type": "edit",
+      "id": "d618f0df06ca75db",
+      "item": {
+        "type": "paragraph",
+        "id": "d618f0df06ca75db",
+        "text": "The Video Plugin embeds a video player on a wiki page. The video itself must be uploaded to a supported video site and the key from that service used to configure the plugin. Drag and drop makes this easy in some cases."
+      },
+      "date": 1416116782161
     }
   ]
 }

--- a/pages/key-from-a-ted-talk
+++ b/pages/key-from-a-ted-talk
@@ -1,0 +1,235 @@
+{
+  "title": "Key from a TED Talk",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "37c161aed68a076d",
+      "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+    },
+    {
+      "type": "paragraph",
+      "id": "d9c4310de1d386fd",
+      "text": "TED keys are underscored words, like hans_rosling_and_the_magic_washing_machine"
+    },
+    {
+      "type": "code",
+      "id": "d15f3ec4e8d1fc70",
+      "text": "http://www.ted.com/talks/hans_rosling_and_the_magic_washing_machine"
+    },
+    {
+      "type": "code",
+      "id": "d1c1d11ea8e6f260",
+      "text": "<iframe src=\"https://embed-ssl.ted.com/talks/hans_rosling_and_the_magic_washing_machine.html\" width=\"560\" height=\"315\" frameborder=\"0\" scrolling=\"no\" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>"
+    },
+    {
+      "type": "paragraph",
+      "id": "1e26bf9c1363fd03",
+      "text": "This is an embedded video from TED. Double-click the caption to see the plugin markup."
+    },
+    {
+      "type": "video",
+      "id": "a64edb5c4c6d9d73",
+      "text": "TED hans_rosling_and_the_magic_washing_machine\nHans Rosling"
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Key from a TED Talk",
+        "story": []
+      },
+      "date": 1416114707328
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "d15f3ec4e8d1fc70"
+      },
+      "id": "d15f3ec4e8d1fc70",
+      "type": "add",
+      "date": 1416115259465
+    },
+    {
+      "type": "edit",
+      "id": "d15f3ec4e8d1fc70",
+      "item": {
+        "type": "code",
+        "id": "d15f3ec4e8d1fc70",
+        "text": "http://www.ted.com/talks/hans_rosling_and_the_magic_washing_machine"
+      },
+      "date": 1416115265257
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "37c161aed68a076d"
+      },
+      "id": "37c161aed68a076d",
+      "type": "add",
+      "after": "d15f3ec4e8d1fc70",
+      "date": 1416115291950
+    },
+    {
+      "type": "edit",
+      "id": "37c161aed68a076d",
+      "item": {
+        "type": "paragraph",
+        "id": "37c161aed68a076d",
+        "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+      },
+      "date": 1416115296131
+    },
+    {
+      "type": "move",
+      "order": [
+        "37c161aed68a076d",
+        "d15f3ec4e8d1fc70"
+      ],
+      "id": "37c161aed68a076d",
+      "date": 1416115298818
+    },
+    {
+      "item": {
+        "type": "paragraph",
+        "id": "d9c4310de1d386fd",
+        "text": ""
+      },
+      "id": "d9c4310de1d386fd",
+      "type": "add",
+      "after": "37c161aed68a076d",
+      "date": 1416115322273
+    },
+    {
+      "type": "edit",
+      "id": "d9c4310de1d386fd",
+      "item": {
+        "type": "paragraph",
+        "id": "d9c4310de1d386fd",
+        "text": "TED keys are hyphenated words, like TEDxPortland-Ward-Cunningham"
+      },
+      "date": 1416115331838
+    },
+    {
+      "type": "edit",
+      "id": "d9c4310de1d386fd",
+      "item": {
+        "type": "paragraph",
+        "id": "d9c4310de1d386fd",
+        "text": "TED keys are underscored words, like hans_rosling_and_the_magic_washing_machine"
+      },
+      "date": 1416115385337
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "d1c1d11ea8e6f260"
+      },
+      "id": "d1c1d11ea8e6f260",
+      "type": "add",
+      "after": "d15f3ec4e8d1fc70",
+      "date": 1416115408933
+    },
+    {
+      "type": "edit",
+      "id": "d1c1d11ea8e6f260",
+      "item": {
+        "type": "code",
+        "id": "d1c1d11ea8e6f260",
+        "text": "<iframe src=\"https://embed-ssl.ted.com/talks/hans_rosling_and_the_magic_washing_machine.html\" width=\"560\" height=\"315\" frameborder=\"0\" scrolling=\"no\" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>"
+      },
+      "date": 1416115419284
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "1e26bf9c1363fd03"
+      },
+      "id": "1e26bf9c1363fd03",
+      "type": "add",
+      "after": "d1c1d11ea8e6f260",
+      "date": 1416115489893
+    },
+    {
+      "type": "edit",
+      "id": "1e26bf9c1363fd03",
+      "item": {
+        "type": "paragraph",
+        "id": "1e26bf9c1363fd03",
+        "text": "This is an embedded video from TED. Double-click the caption to see the plugin markup."
+      },
+      "date": 1416115499761
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "5c79599a772e80fb"
+      },
+      "id": "5c79599a772e80fb",
+      "type": "add",
+      "after": "1e26bf9c1363fd03",
+      "date": 1416115515526
+    },
+    {
+      "item": {
+        "type": "paragraph",
+        "id": "cc6baa18c1ddd883",
+        "text": ""
+      },
+      "id": "cc6baa18c1ddd883",
+      "type": "add",
+      "after": "5c79599a772e80fb",
+      "date": 1416115524932
+    },
+    {
+      "type": "remove",
+      "id": "cc6baa18c1ddd883",
+      "date": 1416115529052
+    },
+    {
+      "type": "remove",
+      "id": "5c79599a772e80fb",
+      "date": 1416115538137
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "a64edb5c4c6d9d73"
+      },
+      "id": "a64edb5c4c6d9d73",
+      "type": "add",
+      "after": "1e26bf9c1363fd03",
+      "date": 1416115540481
+    },
+    {
+      "type": "edit",
+      "id": "a64edb5c4c6d9d73",
+      "item": {
+        "type": "video",
+        "id": "a64edb5c4c6d9d73",
+        "text": "TED hans_rosling_and_the_magic_washing_machine\nHans Rosling"
+      },
+      "date": 1416115550151
+    },
+    {
+      "type": "edit",
+      "id": "d15f3ec4e8d1fc70",
+      "item": {
+        "type": "code",
+        "id": "d15f3ec4e8d1fc70",
+        "text": "http://www.ted.com/talks/hans_rosling_and_the_\nmagic_washing_machine"
+      },
+      "date": 1416116900333
+    },
+    {
+      "type": "edit",
+      "id": "d15f3ec4e8d1fc70",
+      "item": {
+        "type": "code",
+        "id": "d15f3ec4e8d1fc70",
+        "text": "http://www.ted.com/talks/hans_rosling_and_the_magic_washing_machine"
+      },
+      "date": 1416116908935
+    }
+  ]
+}

--- a/pages/key-from-a-tedx-talk
+++ b/pages/key-from-a-tedx-talk
@@ -1,0 +1,187 @@
+{
+  "title": "Key from a TEDx Talk",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "dced29ed676d5595",
+      "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+    },
+    {
+      "type": "paragraph",
+      "id": "c770b2da5551a027",
+      "text": "TEDx keys are hyphenated words, like TEDxPortland-Ward-Cunningham"
+    },
+    {
+      "type": "code",
+      "id": "8137fb800af40a34",
+      "text": "http://tedxtalks.ted.com/video/TEDxPortland-Ward-Cunningham"
+    },
+    {
+      "type": "code",
+      "id": "c45133b5c7c22db9",
+      "text": "<iframe src=\"http://tedxtalks.ted.com/video/TEDxPortland-Ward-Cunningham/player?layout=&amp;read_more=1\" width=\"416\" height=\"321\" frameborder=\"0\" scrolling=\"no\"></iframe>"
+    },
+    {
+      "type": "paragraph",
+      "id": "3e15a5ed0e8a8f8b",
+      "text": "This is an embedded video from TEDx. Double-click the caption to see the plugin markup."
+    },
+    {
+      "type": "video",
+      "id": "792c41bb8753fc57",
+      "text": "TEDX TEDxPortland-Ward-Cunningham\nWard Cunningham"
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Key from a TEDx Talk",
+        "story": []
+      },
+      "date": 1416114725247
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "dced29ed676d5595"
+      },
+      "id": "dced29ed676d5595",
+      "type": "add",
+      "date": 1416114727078
+    },
+    {
+      "type": "edit",
+      "id": "dced29ed676d5595",
+      "item": {
+        "type": "paragraph",
+        "id": "dced29ed676d5595",
+        "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+      },
+      "date": 1416114734743
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "c770b2da5551a027"
+      },
+      "id": "c770b2da5551a027",
+      "type": "add",
+      "after": "dced29ed676d5595",
+      "date": 1416114761032
+    },
+    {
+      "type": "edit",
+      "id": "c770b2da5551a027",
+      "item": {
+        "type": "paragraph",
+        "id": "c770b2da5551a027",
+        "text": "TEDx keys are letters and digits, like ziMLDgsefi0"
+      },
+      "date": 1416114787591
+    },
+    {
+      "type": "edit",
+      "id": "c770b2da5551a027",
+      "item": {
+        "type": "paragraph",
+        "id": "c770b2da5551a027",
+        "text": "TEDx keys are hyphenated words, like TEDxPortland-Ward-Cunningham"
+      },
+      "date": 1416114821096
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "8137fb800af40a34"
+      },
+      "id": "8137fb800af40a34",
+      "type": "add",
+      "after": "c770b2da5551a027",
+      "date": 1416114846386
+    },
+    {
+      "type": "edit",
+      "id": "8137fb800af40a34",
+      "item": {
+        "type": "code",
+        "id": "8137fb800af40a34",
+        "text": "http://tedxtalks.ted.com/video/TEDxPortland-Ward-Cunningham"
+      },
+      "date": 1416114852547
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "c45133b5c7c22db9"
+      },
+      "id": "c45133b5c7c22db9",
+      "type": "add",
+      "after": "8137fb800af40a34",
+      "date": 1416114882930
+    },
+    {
+      "type": "edit",
+      "id": "c45133b5c7c22db9",
+      "item": {
+        "type": "code",
+        "id": "c45133b5c7c22db9",
+        "text": "<iframe src=\"http://tedxtalks.ted.com/video/TEDxPortland-Ward-Cunningham/player?layout=&amp;read_more=1\" width=\"416\" height=\"321\" frameborder=\"0\" scrolling=\"no\"></iframe>"
+      },
+      "date": 1416114909775
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "792c41bb8753fc57"
+      },
+      "id": "792c41bb8753fc57",
+      "type": "add",
+      "after": "c45133b5c7c22db9",
+      "date": 1416114942717
+    },
+    {
+      "type": "edit",
+      "id": "792c41bb8753fc57",
+      "item": {
+        "type": "video",
+        "id": "792c41bb8753fc57",
+        "text": "TEDX TEDxPortland-Ward-Cunningham\nWard Cunningham"
+      },
+      "date": 1416114967475
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "3e15a5ed0e8a8f8b"
+      },
+      "id": "3e15a5ed0e8a8f8b",
+      "type": "add",
+      "after": "792c41bb8753fc57",
+      "date": 1416115020510
+    },
+    {
+      "type": "edit",
+      "id": "3e15a5ed0e8a8f8b",
+      "item": {
+        "type": "paragraph",
+        "id": "3e15a5ed0e8a8f8b",
+        "text": "This is an embedded video from TEDx. Double-click the caption to see the plugin markup."
+      },
+      "date": 1416115033034
+    },
+    {
+      "type": "move",
+      "order": [
+        "dced29ed676d5595",
+        "c770b2da5551a027",
+        "8137fb800af40a34",
+        "c45133b5c7c22db9",
+        "3e15a5ed0e8a8f8b",
+        "792c41bb8753fc57"
+      ],
+      "id": "3e15a5ed0e8a8f8b",
+      "date": 1416115035623
+    }
+  ]
+}

--- a/pages/key-from-internet-archive
+++ b/pages/key-from-internet-archive
@@ -1,0 +1,218 @@
+{
+  "title": "Key from Internet Archive",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "688035bb092b12de",
+      "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+    },
+    {
+      "type": "paragraph",
+      "id": "a8bce2b5b5f58301",
+      "text": "Internet Archive keys are words, numbers and punctuation, like Timothy_Leary_Archives_178.dv"
+    },
+    {
+      "type": "code",
+      "id": "d46086d65d7c3ab9",
+      "text": "https://archive.org/details/Timothy_Leary_Archives_178.dv"
+    },
+    {
+      "type": "code",
+      "id": "cb71a37f649c6f39",
+      "text": "<iframe src=\"https://archive.org/embed/Timothy_Leary_Archives_178.dv\" width=\"640\" height=\"480\" frameborder=\"0\" allowfullscreen></iframe>"
+    },
+    {
+      "type": "paragraph",
+      "id": "84790476d6c7ab64",
+      "text": "This is an embedded video from the Internet Archive. Double-click the caption to see the plugin markup.\n"
+    },
+    {
+      "type": "video",
+      "id": "bc0458f8f7593bd1",
+      "text": "ARCHIVE Timothy_Leary_Archives_178.dv\nTimothy Leary's final visit with the Merry Pranksters in Colorado (1995)"
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Key from Internet Archive",
+        "story": []
+      },
+      "date": 1416110778038
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "688035bb092b12de"
+      },
+      "id": "688035bb092b12de",
+      "type": "add",
+      "date": 1416110779811
+    },
+    {
+      "type": "edit",
+      "id": "688035bb092b12de",
+      "item": {
+        "type": "paragraph",
+        "id": "688035bb092b12de",
+        "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+      },
+      "date": 1416110783394
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "d46086d65d7c3ab9"
+      },
+      "id": "d46086d65d7c3ab9",
+      "type": "add",
+      "after": "688035bb092b12de",
+      "date": 1416111362412
+    },
+    {
+      "type": "edit",
+      "id": "d46086d65d7c3ab9",
+      "item": {
+        "type": "code",
+        "id": "d46086d65d7c3ab9",
+        "text": "https://archive.org/details/Timothy_Leary_Archives_178.dv"
+      },
+      "date": 1416111372784
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "cb71a37f649c6f39"
+      },
+      "id": "cb71a37f649c6f39",
+      "type": "add",
+      "after": "d46086d65d7c3ab9",
+      "date": 1416111422463
+    },
+    {
+      "type": "edit",
+      "id": "cb71a37f649c6f39",
+      "item": {
+        "type": "code",
+        "id": "cb71a37f649c6f39",
+        "text": "<iframe src=\"https://archive.org/embed/Timothy_Leary_Archives_178.dv\" width=\"640\" height=\"480\" frameborder=\"0\" webkitallowfullscreen=\"true\" mozallowfullscreen=\"true\" allowfullscreen></iframe>"
+      },
+      "date": 1416111434770
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "bc0458f8f7593bd1"
+      },
+      "id": "bc0458f8f7593bd1",
+      "type": "add",
+      "after": "cb71a37f649c6f39",
+      "date": 1416111475810
+    },
+    {
+      "type": "edit",
+      "id": "bc0458f8f7593bd1",
+      "item": {
+        "type": "video",
+        "id": "bc0458f8f7593bd1",
+        "text": "ARCHIVE Timothy_Leary_Archives_178.dv\nlksjd"
+      },
+      "date": 1416111509313
+    },
+    {
+      "type": "edit",
+      "id": "bc0458f8f7593bd1",
+      "item": {
+        "type": "video",
+        "id": "bc0458f8f7593bd1",
+        "text": "ARCHIVE Timothy_Leary_Archives_178.dv\nTimothy Leary's final visit with the Merry Pranksters in Colorado (1995)"
+      },
+      "date": 1416111656205
+    },
+    {
+      "item": {
+        "type": "paragraph",
+        "id": "a8bce2b5b5f58301",
+        "text": ""
+      },
+      "id": "a8bce2b5b5f58301",
+      "type": "add",
+      "after": "688035bb092b12de",
+      "date": 1416111730602
+    },
+    {
+      "type": "edit",
+      "id": "a8bce2b5b5f58301",
+      "item": {
+        "type": "paragraph",
+        "id": "a8bce2b5b5f58301",
+        "text": "Internet Archive keys are words, numbers and punctuation."
+      },
+      "date": 1416111775042
+    },
+    {
+      "type": "edit",
+      "id": "a8bce2b5b5f58301",
+      "item": {
+        "type": "paragraph",
+        "id": "a8bce2b5b5f58301",
+        "text": "Internet Archive keys are words, numbers and punctuation, like Timothy_Leary_Archives_178.dv"
+      },
+      "date": 1416111802174
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "84790476d6c7ab64"
+      },
+      "id": "84790476d6c7ab64",
+      "type": "add",
+      "after": "bc0458f8f7593bd1",
+      "date": 1416112205470
+    },
+    {
+      "type": "move",
+      "order": [
+        "688035bb092b12de",
+        "a8bce2b5b5f58301",
+        "d46086d65d7c3ab9",
+        "cb71a37f649c6f39",
+        "84790476d6c7ab64",
+        "bc0458f8f7593bd1"
+      ],
+      "id": "84790476d6c7ab64",
+      "date": 1416112209319
+    },
+    {
+      "type": "edit",
+      "id": "84790476d6c7ab64",
+      "item": {
+        "type": "paragraph",
+        "id": "84790476d6c7ab64",
+        "text": "This is an embedded video from Internet Archive. Double-click the caption to see the plugin markup.\n"
+      },
+      "date": 1416112228903
+    },
+    {
+      "type": "edit",
+      "id": "84790476d6c7ab64",
+      "item": {
+        "type": "paragraph",
+        "id": "84790476d6c7ab64",
+        "text": "This is an embedded video from the Internet Archive. Double-click the caption to see the plugin markup.\n"
+      },
+      "date": 1416112237649
+    },
+    {
+      "type": "edit",
+      "id": "cb71a37f649c6f39",
+      "item": {
+        "type": "code",
+        "id": "cb71a37f649c6f39",
+        "text": "<iframe src=\"https://archive.org/embed/Timothy_Leary_Archives_178.dv\" width=\"640\" height=\"480\" frameborder=\"0\" allowfullscreen></iframe>"
+      },
+      "date": 1416112390627
+    }
+  ]
+}

--- a/pages/key-from-vimeo
+++ b/pages/key-from-vimeo
@@ -1,0 +1,160 @@
+{
+  "title": "Key from Vimeo",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "86fb42c7e8a63e91",
+      "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+    },
+    {
+      "type": "paragraph",
+      "id": "8595e1e06ca0aacc",
+      "text": "Vimeo keys are numbers, like 30340726"
+    },
+    {
+      "type": "code",
+      "id": "290c76f66e3e9c3b",
+      "text": "http://vimeo.com/30340726"
+    },
+    {
+      "type": "code",
+      "id": "dd0ce1f995eb7100",
+      "text": "<iframe src=\"//player.vimeo.com/video/30340726?title=0&amp;byline=0&amp;portrait=0\" width=\"420\" height=\"263\" frameborder=\"0\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+    },
+    {
+      "type": "paragraph",
+      "id": "a9f644e7f6607f1d",
+      "text": "This is an embedded video from Vimeo. Double-click the caption to see the plugin markup.\n"
+    },
+    {
+      "type": "video",
+      "id": "ded229e95b858696",
+      "text": "VIMEO 30340726\nWhere is wiki from? Where might it go to? We asked and answered these questions in a 2005 Wikimania keynote. Our answers hold up. Some guide our work today."
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Key from Vimeo",
+        "story": []
+      },
+      "date": 1416110689237
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "86fb42c7e8a63e91"
+      },
+      "id": "86fb42c7e8a63e91",
+      "type": "add",
+      "date": 1416110698828
+    },
+    {
+      "type": "edit",
+      "id": "86fb42c7e8a63e91",
+      "item": {
+        "type": "paragraph",
+        "id": "86fb42c7e8a63e91",
+        "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+      },
+      "date": 1416110702061
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "8595e1e06ca0aacc",
+        "text": "Vimeo keys are numbers, like 30340726"
+      },
+      "after": "86fb42c7e8a63e91",
+      "id": "8595e1e06ca0aacc",
+      "date": 1416110717810
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "code",
+        "id": "290c76f66e3e9c3b",
+        "text": "http://vimeo.com/30340726"
+      },
+      "after": "8595e1e06ca0aacc",
+      "id": "290c76f66e3e9c3b",
+      "date": 1416110721534
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "code",
+        "id": "dd0ce1f995eb7100",
+        "text": "<iframe src=\"//player.vimeo.com/video/30340726?title=0&amp;byline=0&amp;portrait=0\" width=\"420\" height=\"263\" frameborder=\"0\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"
+      },
+      "after": "290c76f66e3e9c3b",
+      "id": "dd0ce1f995eb7100",
+      "date": 1416110725001
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "ded229e95b858696"
+      },
+      "id": "ded229e95b858696",
+      "type": "add",
+      "after": "dd0ce1f995eb7100",
+      "date": 1416111844080
+    },
+    {
+      "type": "edit",
+      "id": "ded229e95b858696",
+      "item": {
+        "type": "video",
+        "id": "ded229e95b858696",
+        "text": "VIMEO 30340726"
+      },
+      "date": 1416111861962
+    },
+    {
+      "type": "edit",
+      "id": "ded229e95b858696",
+      "item": {
+        "type": "video",
+        "id": "ded229e95b858696",
+        "text": "VIMEO 30340726\nWhere is wiki from? Where might it go to? We asked and answered these questions in a 2005 Wikimania keynote. Our answers hold up. Some guide our work today."
+      },
+      "date": 1416111896399
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "a9f644e7f6607f1d"
+      },
+      "id": "a9f644e7f6607f1d",
+      "type": "add",
+      "after": "ded229e95b858696",
+      "date": 1416112175049
+    },
+    {
+      "type": "move",
+      "order": [
+        "86fb42c7e8a63e91",
+        "8595e1e06ca0aacc",
+        "290c76f66e3e9c3b",
+        "dd0ce1f995eb7100",
+        "a9f644e7f6607f1d",
+        "ded229e95b858696"
+      ],
+      "id": "a9f644e7f6607f1d",
+      "date": 1416112178007
+    },
+    {
+      "type": "edit",
+      "id": "a9f644e7f6607f1d",
+      "item": {
+        "type": "paragraph",
+        "id": "a9f644e7f6607f1d",
+        "text": "This is an embedded video from Vimeo. Double-click the caption to see the plugin markup.\n"
+      },
+      "date": 1416112189164
+    }
+  ]
+}

--- a/pages/key-from-youtube
+++ b/pages/key-from-youtube
@@ -1,0 +1,187 @@
+{
+  "title": "Key from YouTube",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "d7891e6fa0e5c825",
+      "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+    },
+    {
+      "type": "paragraph",
+      "id": "0965aefa76be52c8",
+      "text": "YouTube keys are letters and digits, like ziMLDgsefi0"
+    },
+    {
+      "type": "code",
+      "id": "fba1060fa13d3f4d",
+      "text": "http://youtu.be/ziMLDgsefi0"
+    },
+    {
+      "type": "code",
+      "id": "65c9b3bdb77605cc",
+      "text": "http://www.youtube.com/watch?v=ziMLDgsefi0"
+    },
+    {
+      "type": "code",
+      "id": "a252d2b4f7c83524",
+      "text": "<iframe width=\"420\" height=\"315\" src=\"//www.youtube.com/embed/ziMLDgsefi0?rel=0\" frameborder=\"0\" allowfullscreen></iframe>"
+    },
+    {
+      "type": "paragraph",
+      "id": "8ad93078e4ab67fd",
+      "text": "This is an embedded video from YouTube. Double-click the caption to see the plugin markup."
+    },
+    {
+      "type": "video",
+      "id": "c44e1af1c4a65bfc",
+      "text": "YOUTUBE ziMLDgsefi0\nWe show how to drag and drop pages into one browser tab before making them part of one wiki."
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Key from YouTube",
+        "story": []
+      },
+      "date": 1416110310863
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "d7891e6fa0e5c825"
+      },
+      "id": "d7891e6fa0e5c825",
+      "type": "add",
+      "date": 1416110350377
+    },
+    {
+      "type": "edit",
+      "id": "d7891e6fa0e5c825",
+      "item": {
+        "type": "paragraph",
+        "id": "d7891e6fa0e5c825",
+        "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+      },
+      "date": 1416110621419
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "0965aefa76be52c8",
+        "text": "YouTube keys are letters and digits, like ziMLDgsefi0"
+      },
+      "after": "d7891e6fa0e5c825",
+      "id": "0965aefa76be52c8",
+      "date": 1416110638870
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "code",
+        "id": "fba1060fa13d3f4d",
+        "text": "http://youtu.be/ziMLDgsefi0"
+      },
+      "after": "0965aefa76be52c8",
+      "id": "fba1060fa13d3f4d",
+      "date": 1416110643442
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "code",
+        "id": "65c9b3bdb77605cc",
+        "text": "http://www.youtube.com/watch?v=ziMLDgsefi0"
+      },
+      "after": "fba1060fa13d3f4d",
+      "id": "65c9b3bdb77605cc",
+      "date": 1416110648326
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "code",
+        "id": "a252d2b4f7c83524",
+        "text": "<iframe width=\"420\" height=\"315\" src=\"//www.youtube.com/embed/ziMLDgsefi0?rel=0\" frameborder=\"0\" allowfullscreen></iframe>"
+      },
+      "after": "65c9b3bdb77605cc",
+      "id": "a252d2b4f7c83524",
+      "date": 1416110653356
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "c44e1af1c4a65bfc"
+      },
+      "id": "c44e1af1c4a65bfc",
+      "type": "add",
+      "after": "a252d2b4f7c83524",
+      "date": 1416111938025
+    },
+    {
+      "type": "edit",
+      "id": "c44e1af1c4a65bfc",
+      "item": {
+        "type": "video",
+        "id": "c44e1af1c4a65bfc",
+        "text": "YOUTUBE ziMLDgsefi0\nlkjsf"
+      },
+      "date": 1416111948004
+    },
+    {
+      "type": "edit",
+      "id": "c44e1af1c4a65bfc",
+      "item": {
+        "type": "video",
+        "id": "c44e1af1c4a65bfc",
+        "text": "YOUTUBE ziMLDgsefi0\nWe show how to drag and drop pages into one browser tab before making them part of one wiki."
+      },
+      "date": 1416111989458
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "8ad93078e4ab67fd"
+      },
+      "id": "8ad93078e4ab67fd",
+      "type": "add",
+      "after": "c44e1af1c4a65bfc",
+      "date": 1416112013037
+    },
+    {
+      "type": "move",
+      "order": [
+        "d7891e6fa0e5c825",
+        "0965aefa76be52c8",
+        "fba1060fa13d3f4d",
+        "65c9b3bdb77605cc",
+        "a252d2b4f7c83524",
+        "8ad93078e4ab67fd",
+        "c44e1af1c4a65bfc"
+      ],
+      "id": "8ad93078e4ab67fd",
+      "date": 1416112017406
+    },
+    {
+      "type": "edit",
+      "id": "8ad93078e4ab67fd",
+      "item": {
+        "type": "paragraph",
+        "id": "8ad93078e4ab67fd",
+        "text": "This is an embedded video from YouTube. Double-click the caption to see the markup."
+      },
+      "date": 1416112124208
+    },
+    {
+      "type": "edit",
+      "id": "8ad93078e4ab67fd",
+      "item": {
+        "type": "paragraph",
+        "id": "8ad93078e4ab67fd",
+        "text": "This is an embedded video from YouTube. Double-click the caption to see the plugin markup."
+      },
+      "date": 1416112134635
+    }
+  ]
+}


### PR DESCRIPTION
Generate embed codes for Internet Archive and TED talks. Make the about page more generic and add additional help pages for samples of each video service.

This pull request will be soon followed by a wiki-client pull request to add Factory plugin drop handling for these services. 
