### PR TITLE
undo - problems with edit

### DIFF
--- a/client/video.coffee
+++ b/client/video.coffee
@@ -1,7 +1,3 @@
-load = (callback) ->
-  if(!$("link[href='plugins/video/video.css']").length)
-    $('<link href="/plugins/video/video.css" rel="stylesheet" type="text/css">').appendTo("head")
-
 parse = (text='') ->
   result = {}
   for line in text.split /\r\n?|\n/
@@ -71,7 +67,7 @@ emit = ($item, item) ->
   """
 
 bind = ($item, item) ->
-  load -> $item.dblclick -> wiki.textEditor $item, item
+  $item.dblclick -> wiki.textEditor $item, item
 
 window.plugins.video = {emit, bind} if window?
 module.exports = {parse, embed} if module?


### PR DESCRIPTION
This is undoing the earlier change that added a stylesheet to add some spacing at the top and bottom of the video within the plugin, rather than use the stylesheet in the client.
