### PR TITLE
Add Support for YouTube Playlists

### DIFF
--- a/client/video.coffee
+++ b/client/video.coffee
@@ -16,7 +16,6 @@ parse = (text='') ->
       result.player = args[1]
       result.options = args[2]
       result.key = args[3]
-      console.log 'video with options:', result
     else
       result.caption ||= ' '
       result.caption += line + ' '
@@ -46,8 +45,8 @@ embed = ({player, options, key}) ->
     when 'VIMEO'
       """
         <iframe
-          src="//player.vimeo.com/video/#{key}?title=0&amp;byline=0&amp;portrait=0"
-          width="420" height="263"
+          src="https://player.vimeo.com/video/#{key}?title=0&amp;byline=0&amp;portrait=0"
+          width="420" height="236"
           frameborder="0"
           allowfullscreen>
         </iframe>

--- a/client/video.coffee
+++ b/client/video.coffee
@@ -55,7 +55,7 @@ embed = ({player, options, key}) ->
       """
         <iframe
           src="https://archive.org/embed/#{key}"
-          width="420" height="300"
+          width="420" height="315"
           frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true"
           allowfullscreen>
         </iframe>

--- a/client/video.coffee
+++ b/client/video.coffee
@@ -80,8 +80,8 @@ embed = ({player, options, key}) ->
     when 'CHANNEL9'
       """
         <iframe
-          src="//channel9.msdn.com/#{key}/player"
-          width="420" height="300"
+          src="https://channel9.msdn.com/#{key}/player"
+          width="420" height="236"
           allowFullScreen frameBorder="0">
         </iframe>
       """

--- a/client/video.coffee
+++ b/client/video.coffee
@@ -21,8 +21,8 @@ embed = ({player, key}) ->
     when 'YOUTUBE'
       """
         <iframe
-          width="420" height="315"
-          src="//www.youtube.com/embed/#{key}?rel=0"
+          width="420" height="236"
+          src="https://www.youtube-nocookie.com/embed/#{key}?rel=0"
           frameborder="0"
           allowfullscreen>
         </iframe>

--- a/client/video.coffee
+++ b/client/video.coffee
@@ -10,23 +10,39 @@ parse = (text='') ->
   for line in text.split /\r\n?|\n/
     if args = line.match /^\s*([A-Z0-9]+)\s+([\w\.\-\/+0-9]+)\s*$/
       result.player = args[1]
+      result.options = ''
       result.key = args[2]
+    else if args = line.match /^\s*([A-Z0-9]+)\s+([A-Za-z\,]+)\s+([\w\.\-\/+0-9]+)\s*$/
+      result.player = args[1]
+      result.options = args[2]
+      result.key = args[3]
+      console.log 'video with options:', result
     else
       result.caption ||= ' '
       result.caption += line + ' '
   result
 
-embed = ({player, key}) ->
+embed = ({player, options, key}) ->
   switch player
     when 'YOUTUBE'
-      """
-        <iframe
-          width="420" height="236"
-          src="https://www.youtube-nocookie.com/embed/#{key}?rel=0"
-          frameborder="0"
-          allowfullscreen>
-        </iframe>
-      """
+      if options.toUpperCase() is "PLAYLIST"
+        """
+          <iframe
+            width="420" height="236"
+            src="https://www.youtube-nocookie.com/embed/videoseries?list=#{key}"
+            frameborder="0"
+            allowfullscreen>
+          </iframe>
+        """
+      else
+        """
+          <iframe
+            width="420" height="236"
+            src="https://www.youtube-nocookie.com/embed/#{key}?rel=0"
+            frameborder="0"
+            allowfullscreen>
+          </iframe>
+        """
     when 'VIMEO'
       """
         <iframe

--- a/pages/about-video-plugin
+++ b/pages/about-video-plugin
@@ -57,6 +57,11 @@
       "text": "Say <b>YOUTUBE</b> and a [[Key from YouTube]]."
     },
     {
+      "type": "markdown",
+      "id": "55173cbaf083f586",
+      "text": "Say **YOUTUBE PLAYLIST** and a [[Key from YouTube Playlist]]."
+    },
+    {
       "type": "html",
       "id": "2b9d57899e235839",
       "text": "Say <b>VIMEO</b> and a [[Key from Vimeo]]."
@@ -1154,6 +1159,61 @@
         "text": "Say **CHANNEL9** and a [[Key from a Channel 9 Talk]]"
       },
       "date": 1433689319913
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "55173cbaf083f586"
+      },
+      "id": "55173cbaf083f586",
+      "type": "add",
+      "after": "1adccc792e546ac6",
+      "date": 1475073163650
+    },
+    {
+      "type": "move",
+      "order": [
+        "d618f0df06ca75db",
+        "016470be0fd656b0",
+        "c4fe571a7d4b9266",
+        "23467e76c7406b75",
+        "b262d0358a094b85",
+        "288ca54be42b6221",
+        "766ee886eec15a62",
+        "0fe016e2e2cec946",
+        "df4d9685b5f1a93c",
+        "edd992beacdadf20",
+        "31ed01021009e01c",
+        "55173cbaf083f586",
+        "2b9d57899e235839",
+        "b482e0a6e80d235c",
+        "079161c9324efd8f",
+        "6c1ced54ed7e15b9",
+        "2e69d5aa0f67d445",
+        "1adccc792e546ac6"
+      ],
+      "id": "55173cbaf083f586",
+      "date": 1475073168173
+    },
+    {
+      "type": "edit",
+      "id": "55173cbaf083f586",
+      "item": {
+        "type": "markdown",
+        "id": "55173cbaf083f586",
+        "text": "Say **YOUTUBE PLAYLIST** and a [[Key from YouTube playlist]]."
+      },
+      "date": 1475073216525
+    },
+    {
+      "type": "edit",
+      "id": "55173cbaf083f586",
+      "item": {
+        "type": "markdown",
+        "id": "55173cbaf083f586",
+        "text": "Say **YOUTUBE PLAYLIST** and a [[Key from YouTube Playlist]]."
+      },
+      "date": 1475073246067
     }
   ],
   "plugin": "video"

--- a/pages/key-from-youtube-playlist
+++ b/pages/key-from-youtube-playlist
@@ -1,0 +1,207 @@
+{
+  "title": "Key from YouTube Playlist",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "d7891e6fa0e5c825",
+      "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+    },
+    {
+      "type": "paragraph",
+      "id": "f20d12415cafd0a7",
+      "text": "YouTube playlist keys are letters digits underscore and dash, like PLRdZ44gFTfl3hobkAy5P-_51uIcn_h5oj"
+    },
+    {
+      "type": "code",
+      "id": "ba7075838fc9e2c8",
+      "text": "https://www.youtube.com/playlist?list=PLRdZ44gFTfl3hobkAy5P-_51uIcn_h5oj"
+    },
+    {
+      "type": "code",
+      "id": "2f35f90a05a5eae6",
+      "text": "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/videoseries?list=PLRdZ44gFTfl3hobkAy5P-_51uIcn_h5oj\" frameborder=\"0\" allowfullscreen></iframe>"
+    },
+    {
+      "type": "paragraph",
+      "id": "2c4f44ee9e102c0a",
+      "text": "You will see an extra parameter that identifies the current video, if you are currently watching the playlist."
+    },
+    {
+      "type": "paragraph",
+      "id": "0508828ec422f56b",
+      "text": "For embedded videos you might see `www.youtube-nocookie.com` addresses, if the author has enabled \"privacy-enhanced mode.\" This mode is enabled in this video plugin."
+    },
+    {
+      "type": "paragraph",
+      "id": "9188c9fcf9c5d4df",
+      "text": "This is an embedded playlist from YouTube. Double-click the caption to see the plugin markup."
+    },
+    {
+      "type": "video",
+      "id": "3b2490c73de46735",
+      "text": "YOUTUBE PLAYLIST PLRdZ44gFTfl3hobkAy5P-_51uIcn_h5oj\nA sequence of simulations, by Mike Caulfield, to illustrate how ideas spread through a federation. This is the fifth part of a larger presentation, Federated Education: New Directions in Digital Collaboration. [http://hapgood.us/2014/11/06/federated-education-new-directions-in-digital-collaboration/ webpage]"
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Key from YouTube Playlist",
+        "story": []
+      },
+      "date": 1475073254889
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "d7891e6fa0e5c825",
+        "text": "We explain how to recognize media keys for this service. Read [[About Video Plugin]] to understand media keys and the other services supported by the plugin."
+      },
+      "id": "d7891e6fa0e5c825",
+      "date": 1475073469747
+    },
+    {
+      "type": "add",
+      "id": "f20d12415cafd0a7",
+      "item": {
+        "type": "paragraph",
+        "id": "f20d12415cafd0a7",
+        "text": "YouTube playlist keys are letters digits underscore and dash, like PLRdZ44gFTfl3hobkAy5P-_51uIcn_h5oj"
+      },
+      "after": "d7891e6fa0e5c825",
+      "date": 1475074746492
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "ba7075838fc9e2c8"
+      },
+      "id": "ba7075838fc9e2c8",
+      "type": "add",
+      "after": "f20d12415cafd0a7",
+      "date": 1475074750600
+    },
+    {
+      "type": "edit",
+      "id": "ba7075838fc9e2c8",
+      "item": {
+        "type": "code",
+        "id": "ba7075838fc9e2c8",
+        "text": "https://www.youtube.com/playlist?list=PLRdZ44gFTfl3hobkAy5P-_51uIcn_h5oj"
+      },
+      "date": 1475074771666
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "2f35f90a05a5eae6"
+      },
+      "id": "2f35f90a05a5eae6",
+      "type": "add",
+      "after": "ba7075838fc9e2c8",
+      "date": 1475074797542
+    },
+    {
+      "type": "edit",
+      "id": "2f35f90a05a5eae6",
+      "item": {
+        "type": "code",
+        "id": "2f35f90a05a5eae6",
+        "text": "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/videoseries?list=PLRdZ44gFTfl3hobkAy5P-_51uIcn_h5oj\" frameborder=\"0\" allowfullscreen></iframe>"
+      },
+      "date": 1475074816441
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "2c4f44ee9e102c0a"
+      },
+      "id": "2c4f44ee9e102c0a",
+      "type": "add",
+      "after": "2f35f90a05a5eae6",
+      "date": 1475074830994
+    },
+    {
+      "type": "edit",
+      "id": "2c4f44ee9e102c0a",
+      "item": {
+        "type": "paragraph",
+        "id": "2c4f44ee9e102c0a",
+        "text": "You will see an extra parameter that identifies the current video, if you are currently watching the playlist."
+      },
+      "date": 1475074964567
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "9188c9fcf9c5d4df"
+      },
+      "id": "9188c9fcf9c5d4df",
+      "type": "add",
+      "after": "2c4f44ee9e102c0a",
+      "date": 1475075078223
+    },
+    {
+      "type": "add",
+      "id": "0508828ec422f56b",
+      "item": {
+        "type": "paragraph",
+        "id": "0508828ec422f56b",
+        "text": "For embedded videos you might see `www.youtube-nocookie.com` addresses, if the author has "
+      },
+      "after": "2c4f44ee9e102c0a",
+      "date": 1475075174330
+    },
+    {
+      "type": "edit",
+      "id": "0508828ec422f56b",
+      "item": {
+        "type": "paragraph",
+        "id": "0508828ec422f56b",
+        "text": "For embedded videos you might see `www.youtube-nocookie.com` addresses, if the author has enabled \"privacy-enhanced mode.\" If delays any "
+      },
+      "date": 1475075216730
+    },
+    {
+      "type": "edit",
+      "id": "0508828ec422f56b",
+      "item": {
+        "type": "paragraph",
+        "id": "0508828ec422f56b",
+        "text": "For embedded videos you might see `www.youtube-nocookie.com` addresses, if the author has enabled \"privacy-enhanced mode.\" This mode is enabled in this video plugin."
+      },
+      "date": 1475075289233
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "3b2490c73de46735"
+      },
+      "id": "3b2490c73de46735",
+      "type": "add",
+      "after": "9188c9fcf9c5d4df",
+      "date": 1475076155567
+    },
+    {
+      "type": "edit",
+      "id": "9188c9fcf9c5d4df",
+      "item": {
+        "type": "paragraph",
+        "id": "9188c9fcf9c5d4df",
+        "text": "This is an embedded playlist from YouTube. Double-click the caption to see the plugin markup."
+      },
+      "date": 1475076190085
+    },
+    {
+      "type": "edit",
+      "id": "3b2490c73de46735",
+      "item": {
+        "type": "video",
+        "id": "3b2490c73de46735",
+        "text": "YOUTUBE PLAYLIST PLRdZ44gFTfl3hobkAy5P-_51uIcn_h5oj\nA sequence of simulations, by Mike Caulfield, to illustrate how ideas spread through a federation. This is the fifth part of a larger presentation, Federated Education: New Directions in Digital Collaboration. [http://hapgood.us/2014/11/06/federated-education-new-directions-in-digital-collaboration/ webpage]"
+      },
+      "date": 1475076194819
+    }
+  ]
+}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -40,7 +40,7 @@ describe 'video plugin', ->
       expect(embed).to.match ///
         <iframe
         [^>]*
-        src="//player.vimeo.com/video/12345\?title=0&amp;byline=0&amp;portrait=0"
+        src="https://player.vimeo.com/video/12345\?title=0&amp;byline=0&amp;portrait=0"
         ///
 
     it 'renders Archive video', ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -24,7 +24,7 @@ describe 'video plugin', ->
       expect(embed).to.match ///
         <iframe
         [^>]*
-        src="//www\.youtube\.com/embed/12345\?rel=0"
+        src="https://www\.youtube-nocookie\.com/embed/12345\?rel=0"
         ///
 
     it 'renders Vimeo video', ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -20,11 +20,19 @@ describe 'video plugin', ->
   describe 'embedding', ->
 
     it 'renders Youtube video', ->
-      embed = video.embed({ player: 'YOUTUBE', key: '12345'  })
+      embed = video.embed({ player: 'YOUTUBE', options: '', key: '12345'  })
       expect(embed).to.match ///
         <iframe
         [^>]*
         src="https://www\.youtube-nocookie\.com/embed/12345\?rel=0"
+        ///
+
+    it 'renders Youtube playlist', ->
+      embed = video.embed({ player: 'YOUTUBE', options: 'PLAYLIST', key: '12345' })
+      expect(embed).to.match ///
+        <iframe
+        [^>]*
+        src="https://www\.youtube-nocookie\.com/embed/videoseries\?list=12345"
         ///
 
     it 'renders Vimeo video', ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -72,7 +72,7 @@ describe 'video plugin', ->
       expect(embed).to.match ///
         <iframe
         [^>]*
-        src="//channel9.msdn.com/12345/player"
+        src="https://channel9.msdn.com/12345/player"
         ///
 
     it 'renders fallback text when player is not recognized', ->


### PR DESCRIPTION
Here we add the ability to embed YouTube playlists.

N.B. This does not enable support for dropping a playlist, as drop is currently handled within the client, a related change will be coming later.

YouTube embed switches to use privacy-enhanded mode.

We also trim the proportions of the embedded video, where the information is available, so they fit better.